### PR TITLE
change version, remove riddley in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ The core version declaration tells the boot loader which version of the boot
 core to use:
 
 ```clojure
-#tailrecursion.boot.core/version "2.0.0"
+#tailrecursion.boot.core/version "2.3.1"
 ```
 
 Any remaining forms in the script file are evaluated in the boot environment:
 
 ```clojure
-(set-env! :dependencies '[[riddley "0.3.4"]])
+(set-env! :dependencies '[[tailrecursion/boot.task "2.1.2"]])
 (require '[clojure.string :refer [join]])
 
 (defn -main [& args]


### PR DESCRIPTION
I kept getting errors like: Could not find artifact riddley:riddley:jar:0.3.4 in http://repo1.maven.org/maven2/. It looks like others have been having problems too:
https://stackoverflow.com/questions/22854308/pomegranate-could-not-be-found-on-class-path
