### PR TITLE
added cyg-boot option in makefile and small change to allow repositories with username/pwd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pom.xml.asc
 /boot
 .nrepl-port
 /build.boot
+*.iml

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ help:
 	@echo
 	@echo 'Targets:'
 	@echo '  boot         Create executable boot jar file.'
+	@echo '  cyg-boot     Create executable boot jar file for use under cygwin.'
 	@echo
 
 clean:
@@ -22,6 +23,14 @@ build: clean
 boot: build
 	echo '#!/usr/bin/env bash' > boot
 	echo 'java $$JVM_OPTS -jar $$0 "$$@"' >> boot
+	echo 'exit' >> boot
+	cat target/boot*-standalone.jar >> boot
+	chmod 0755 boot
+	@echo "*** Done. Created boot executable: ./boot ***"
+
+cyg-boot: build
+	echo '#!/usr/bin/env bash' > boot
+	echo 'java $$JVM_OPTS -jar $$(cygpath -w $$0) "$$@"' >> boot
 	echo 'exit' >> boot
 	cat target/boot*-standalone.jar >> boot
 	chmod 0755 boot

--- a/boot-classloader/src/tailrecursion/boot_classloader.clj
+++ b/boot-classloader/src/tailrecursion/boot_classloader.clj
@@ -63,15 +63,15 @@
   (let [deps (mapv exclude-clj deps)]
     (aether/resolve-dependencies
       :coordinates        deps
-      :repositories       (zipmap repos repos)
+      :repositories       repos
       :transfer-listener  transfer-listener
       :proxy              (get-proxy-settings))))
 
 (defn resolve-dependencies!
   [deps repos]
   (->> (resolve-dependencies!* deps repos)
-    kahn/topo-sort
-    (map (fn [x] {:dep x :jar (.getPath (:file (meta x)))}))))
+       kahn/topo-sort
+       (map (fn [x] {:dep x :jar (.getPath (:file (meta x)))}))))
 
 (defn glob-match? [pattern path]
   (.match (AntPathMatcher.) pattern path))

--- a/boot.bat
+++ b/boot.bat
@@ -1,0 +1,3 @@
+@echo off
+
+java %JVM_OPTS% -jar D:\git-repos\github\bergm\boot\target\boot-1.0.3-standalone.jar "%*"

--- a/src/tailrecursion/boot/loader.clj
+++ b/src/tailrecursion/boot/loader.clj
@@ -58,7 +58,8 @@
 ;; loader ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def min-core-version "2.0.0")
-(def dfl-repos #{"http://clojars.org/repo/" "http://repo1.maven.org/maven2/"})
+(def dfl-repos {"clojars" "http://clojars.org/repo/"
+                "central" "http://repo1.maven.org/maven2/"})
 
 (def ^:private core-dep     (atom nil))
 (def ^:private cl2          (atom nil))


### PR DESCRIPTION
Hi, 

I added some small changes, which would be nice to have added to the code base:
- a new build target "cyg-boot" to use the build procedures under Windows with cygwin, so a Windows user could use the build instructions and also get the commandline (even though just cygwin) working as it is under Linux
- at least for the dev server I needed the artifact resolving to my.datomic.com, a repository with username/pwd and so far the :repository key just was a set
  -> I changed it internally to use maps as pomegranate/aether does and distinguish just in the multi-method between the :repository value being a set or a map
  -> the second part of the change is in boot.core

Michael
