### PR TITLE
update path to boot-classloader jar

### DIFF
--- a/boot-classloader/project.clj
+++ b/boot-classloader/project.clj
@@ -7,5 +7,5 @@
                  [org.springframework/spring-core "1.2.2"]
                  [com.cemerick/pomegranate        "0.2.0" :exclusions [org.clojure/clojure]]]
   :main ^:skip-aot tailrecursion.boot-classloader
-  :target-path "target/%s"
+  :target-path "target" ; force target-path to maintain 2.3 compatibility
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
When I run `make boot`, I get an about the standalone jar not existing. I updated the script to point to the correct location.

```
~/p/boot git:master $ make boot
rm -f boot
rm -rf resources/*
(cd boot-classloader; lein clean)
lein clean
mkdir -p resources
(cd boot-classloader; lein uberjar)
Compiling tailrecursion.boot-classloader.kahnsort
Compiling tailrecursion.boot-classloader
Created /home/me/phaser/boot/boot-classloader/target/uberjar/boot-classloader-0.1.0-SNAPSHOT.jar
Created /home/me/phaser/boot/boot-classloader/target/uberjar/boot-classloader-0.1.0-SNAPSHOT-standalone.jar
cp boot-classloader/target/boot-classloader*-standalone.jar resources/boot-classloader.jar
cp: cannot stat ‘boot-classloader/target/boot-classloader*-standalone.jar’: No such file or directory
Makefile:17: recipe for target 'build' failed
make: *** [build] Error 1
```

Things are looking better after I updated the Makefile:

```
~/p/boot git:master $ make boot                                                                                                                                                                                                            
rm -f boot
rm -rf resources/*
(cd boot-classloader; lein clean)
lein clean
mkdir -p resources
(cd boot-classloader; lein uberjar)
Created /home/me/phaser/boot/boot-classloader/target/uberjar/boot-classloader-0.1.0-SNAPSHOT.jar
Created /home/me/phaser/boot/boot-classloader/target/uberjar/boot-classloader-0.1.0-SNAPSHOT-standalone.jar
cp boot-classloader/target/uberjar/boot-classloader*-standalone.jar resources/boot-classloader.jar
lein uberjar
Compiling tailrecursion.boot.classlojure.core
Compiling tailrecursion.boot.loader
Compiling tailrecursion.boot.semver
Compiling tailrecursion.boot.strap
Created /home/me/phaser/boot/target/boot-1.0.5.jar
Created /home/me/phaser/boot/target/boot-1.0.5-standalone.jar
echo '#!/usr/bin/env bash' > boot
echo 'java $JVM_OPTS -jar $0 "$@"' >> boot
echo 'exit' >> boot
cat target/boot*-standalone.jar >> boot
chmod 0755 boot
*** Done. Created boot executable: ./boot ***
```
